### PR TITLE
Bump dependency bounds

### DIFF
--- a/monad-log.cabal
+++ b/monad-log.cabal
@@ -1,5 +1,5 @@
 name:                monad-log
-version:             0.1.1.0
+version:             0.1.2.0
 synopsis:            A simple and fast logging monad
 description:         
     This package provide a mtl style `MonadLog` class and a concrete monad transformer `LogT`, the main difference between this package and monad-logger are:
@@ -45,12 +45,12 @@ library
                     ,   fast-logger >=2.4.5 && <2.5
                     ,   monad-control >=0.3 && <1.1
                     ,   lifted-base 
-                    ,   exceptions >=0.6 && <0.9
+                    ,   exceptions >=0.6 && <0.11
                     ,   bytestring
                     ,   text
                     ,   text-show
                     ,   transformers >=0.2
-                    ,   aeson        >= 0.4 && <1.2
+                    ,   aeson        >= 0.4 && <1.4
                     ,   template-haskell 
 
   -- hs-source-dirs:      

--- a/monad-log.cabal
+++ b/monad-log.cabal
@@ -50,7 +50,7 @@ library
                     ,   text
                     ,   text-show
                     ,   transformers >=0.2
-                    ,   aeson        >= 0.4 && <0.12
+                    ,   aeson        >= 0.4 && <1.2
                     ,   template-haskell 
 
   -- hs-source-dirs:      


### PR DESCRIPTION
Allow the latest versions of `exceptions` and `aeson`. Bumped minor version given changes to non-orphan instances in these newer dependency versions.